### PR TITLE
Set the bright foreground color in gnome-dark

### DIFF
--- a/gnome-dark.yml
+++ b/gnome-dark.yml
@@ -4,6 +4,7 @@ colors:
   primary:
     foreground: '#d0cfcc'
     background: '#171421'
+    bright_foreground: '#ffffff'
 
   normal:
     black:   '#171421'

--- a/gnome-light.yml
+++ b/gnome-light.yml
@@ -4,6 +4,7 @@ colors:
   primary:
     foreground: '#171421'
     background: '#ffffff'
+    bright_foreground: '#5e5c64'
 
   normal:
     black:   '#171421'


### PR DESCRIPTION
My original intention was that the gnome-dark scheme would use the colour corresponding to 'bright white' as the bright version of the foreground colour. (The default foreground colour is 'normal white'.) This didn't make it into the gnome-terminal code, because the colour scheme settings are not able to set the bright foreground colour. But it can be set here.